### PR TITLE
small issue on Document.score_paragraphs()

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -196,7 +196,7 @@ class Document:
 		#self.debug(str([describe(node) for node in self.tags(self.html, "div")]))
 
 		ordered = []
-		for elem in self.tags(self.html, "p", "pre", "td"):
+		for elem in self.tags(self._html(), "p", "pre", "td"):
 			parent_node = elem.getparent()
 			if parent_node is None:
 				continue 


### PR DESCRIPTION
I found myself wanting to run score_paragraphs() on a Document instance before doing anything else, and came across this bug. 

Take a look at the diff. It's pretty self explanatory. 
