### PR TITLE
Add makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 *.pyc
+*.egg-info
 build
 dist
-readability_lxml.egg-info
+/bin
+/include
+/lib
+/local
+/man
+nosetests.xml
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ bin/python:
 
 .PHONY: clean_venv
 clean_venv:
+<<<<<<< HEAD
 	rm -rf bin include lib local man
+=======
+	rm -rf lib include local bin man
+>>>>>>> 521eea5... ls
 
 develop: lib/python*/site-packages/bookie-api.egg-link
 lib/python*/site-packages/bookie-api.egg-link:


### PR DESCRIPTION
Add makefile testing, building, uploading.
- Adds a makefile with helpers
  - make all will setup a virtualenv and get deps
  - make test will install test deps and run nosetests
  - make version_update will open the setup.py for updating version string
  - make upload will build and upload sdist to pypi
