### PR TITLE
Make lxml clean tree available for user modifications

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -123,6 +123,9 @@ class Document:
     def short_title(self):
         return shorten_title(self._html(True))
 
+    def get_clean_html(self):
+         return clean_attributes(tounicode(self.html))
+
     def summary(self, html_partial=False):
         """Generate the summary of the html docuemnt
 
@@ -530,7 +533,8 @@ class Document:
                 #el.attrib = {} #FIXME:Checkout the effects of disabling this
                 pass
 
-        return clean_attributes(tounicode(node))
+        self.html = node
+        return self.get_clean_html()
 
 
 class HashableElement():


### PR DESCRIPTION
The cleaned lxml object wasn't available outside readability.

It very useful to ask readability to extract and clean an article and then modify the lxml tree before generating a html text stream.

An example to update image link:

``` python
d = readability.Document(html)
d.summary(True)
for i in d.html.findall(".//img"):
        # ... some modification ...
summary = d.get_clean_html()
```
