### PR TITLE
Resolved problem with title.text being None

### DIFF
--- a/readability/htmls.py
+++ b/readability/htmls.py
@@ -43,7 +43,7 @@ def norm_title(title):
 
 def get_title(doc):
     title = doc.find('.//title')
-    if title is None or len(title.text) == 0:
+    if title is None or not title.text:
         return '[no-title]'
 
     return norm_title(title.text)


### PR DESCRIPTION
I’ve gotten this error:

    Traceback (most recent call last):
      File "bin/fetcher", line 46, in <module>
        sys.exit(htmlfx.fetcher.run())
      File "/home/ferret/html-fx/htmlfx/fetcher.py", line 347, in run
        blacklist, default_extractor).listen()
      File "/home/ferret/html-fx/htmlfx/fetcher.py", line 259, in listen
        item = self.process(feed_item)
      File "/home/ferret/html-fx/htmlfx/fetcher.py", line 232, in process
        'title': gist.title,
      File "/home/ferret/html-fx/src/utilofies/utilofies/stdlib.py", line 97, in __get__
        obj.__dict__[self.__name__] = self.func(obj)
      File "/home/ferret/html-fx/htmlfx/extractor.py", line 85, in title
        return self.readability.title()
      File "/home/ferret/.buildout/eggs/readability_lxml-0.3.0.2-py2.7.egg/readability/readability.py", line 136, in title
        return get_title(self._html(True))
      File "/home/ferret/.buildout/eggs/readability_lxml-0.3.0.2-py2.7.egg/readability/htmls.py", line 46, in get_title
        if title is None or len(title.text) == 0:
    TypeError: object of type 'NoneType' has no len()

Do you think my change addresses it properly?