### PR TITLE
Fix mac version comparison in setup.py for 10.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ lxml_requirement = "lxml"
 if sys.platform == 'darwin':
     import platform
     mac_ver = platform.mac_ver()[0]
-    if mac_ver < '10.9':
+    mac_ver_no = int(mac_ver.split('.')[1])
+    if mac_ver_no < 9:
         print "Using lxml<2.4"
         lxml_requirement = "lxml<2.4"
 


### PR DESCRIPTION
`setup.py` checks the Mac version number to determine `lxml` version to install.
This fixes the check for Mac versions >= 10.10.