### PR TITLE
Failure if best_elem is root (fix #58)

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -212,7 +212,9 @@ class Document:
         else:
             output = document_fromstring('<div/>')
         best_elem = best_candidate['elem']
-        for sibling in best_elem.getparent().getchildren():
+        parent = best_elem.getparent()
+        siblings = parent.getchildren() if parent else [best_elem]
+        for sibling in siblings:
             # in lxml there no concept of simple text
             # if isinstance(sibling, NavigableString): continue
             append = False

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -50,3 +50,14 @@ class TestArticleOnly(unittest.TestCase):
         doc = Document(sample)
         res = doc.summary(html_partial=True)
         self.assertEqual('<div><div class="content__article-body ', res[0:39])
+
+    def test_best_elem_is_root_and_passing(self):
+        sample = (
+            '<html class="article" id="body">'
+            '   <body>'
+            '       <p>1234567890123456789012345</p>'
+            '   </body>'
+            '</html>'
+        )
+        doc = Document(sample)
+        doc.summary()


### PR DESCRIPTION
Reproduces and fixes issue https://github.com/buriy/python-readability/issues/58
