### PR TITLE
Move logging.basicConfig to main function

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -17,7 +17,6 @@ from .htmls import get_title
 from .htmls import shorten_title
 
 
-logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
@@ -597,6 +596,8 @@ class HashableElement():
 
 
 def main():
+    logging.basicConfig(level=logging.INFO)
+
     from optparse import OptionParser
     parser = OptionParser(usage="%prog: [options] [file]")
     parser.add_option('-v', '--verbose', action='store_true')


### PR DESCRIPTION
logging.basicConfig should not be called on import level because logging config gets in conflict with other libs using logging and readability lib. 

If you accept this PR, can you please do update to PyPI :)