### PR TITLE
Fixed an issue with passing a list of keywords in string format.

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -68,7 +68,7 @@ def compile_pattern(elements):
     if not elements:
         return None
     elif isinstance(elements, (list, tuple)):
-        return list(elements)
+        return list(re.compile(u'{}'.format(e.lower()),re.U) for e in elements)
     elif isinstance(elements, regexp_type):
         return elements
     else:
@@ -342,16 +342,16 @@ class Document:
                 if REGEXES['positiveRe'].search(feature):
                     weight += 25
 
-                if self.positive_keywords and self.positive_keywords.search(feature):
+                if self.positive_keywords and any(pos_key.search(feature) for pos_key in self.positive_keywords):
                     weight += 25
 
-                if self.negative_keywords and self.negative_keywords.search(feature):
+                if self.negative_keywords and any(neg_key.search(feature) for neg_key in self.negative_keywords):
                     weight -= 25
 
-        if self.positive_keywords and self.positive_keywords.match('tag-'+e.tag):
+        if self.positive_keywords and any(pos_key.match('tag-'+e.tag) for pos_key in self.positive_keywords):
             weight += 25
 
-        if self.negative_keywords and self.negative_keywords.match('tag-'+e.tag):
+        if self.negative_keywords and any(neg_key.match('tag-'+e.tag) for neg_key in self.negative_keywords):
             weight -= 25
 
         return weight


### PR DESCRIPTION
When you tried to use a list of positive or negative keywords in the Document class, it would fail as a list does not have the search or match methods. Simply, I just used short list comprehensions to iterate over the keywords.

This also required that all keywords passed through compile_pattern be turned into compiled regex which I again used list comprehensions to make it work. 

