### PR TITLE
No more stderr logging, only raising exception.

### DIFF
--- a/readability/readability.py
+++ b/readability/readability.py
@@ -217,12 +217,7 @@ class Document:
                 else:
                     return cleaned_article
         except Exception as e:
-            log.exception('error getting summary: ')
-            if sys.version_info[0] == 2:
-                from .compat.two import raise_with_traceback
-            else:
-                from .compat.three import raise_with_traceback
-            raise_with_traceback(Unparseable, sys.exc_info()[2], str_(e))
+            raise Unparseable(e)
 
     def get_article(self, candidates, best_candidate, html_partial=False):
         # Now that we have the top candidate, look through its siblings for


### PR DESCRIPTION
@buriy Thanks for creating this library. I've been using it for filtering media websites. However, I dislike the fact that you would log to stderr when the input HTML was empty and lxml raised an exception. I think the user of the library should choose whether to log or do whatever he pleases with the exception.

I've forked the repo and modified the behaviour to suit my needs but I think it'd be a nice improvement.