### PR TITLE
fix encoding detection to use the encoding being tested

### DIFF
--- a/readability/encoding.py
+++ b/readability/encoding.py
@@ -43,7 +43,7 @@ def get_encoding(page):
             encoding = fix_charset(declared_encoding)
 
             # Now let's decode the page
-            page.decode()
+            page.decode(encoding)
             # It worked!
             return encoding
         except UnicodeDecodeError:


### PR DESCRIPTION
the existing code just does page.decode(), which attempts to use the system default encoding, rather than the value of "encoding", which is what we want to test.