### PR TITLE
Minor Python 3.7 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "3.6"
+  - "3.7"
 
 env:
   - TOX_ENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOX_ENV=py34
 # - TOX_ENV=py35
   - TOX_ENV=py36
+  - TOX_ENV=py37
 
 before_install:
   # work around https://github.com/travis-ci/travis-ci/issues/8363

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 language: python
 
 python:
-  - "3.7"
+  - "3.6"
+
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - name: "Python: 3.7"
+      python: "3.7"
+      dist: xenial
+      sudo: true
+      env: TOX_ENV=py37
 
 env:
   - TOX_ENV=py27
   - TOX_ENV=py34
 # - TOX_ENV=py35
   - TOX_ENV=py36
-  - TOX_ENV=py37
 
 before_install:
   # work around https://github.com/travis-ci/travis-ci/issues/8363

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -9,7 +9,9 @@ SAMPLES = os.path.join(os.path.dirname(__file__), 'samples')
 
 def load_sample(filename):
     """Helper to get the content out of the sample files"""
-    return open(os.path.join(SAMPLES, filename)).read()
+    with open(os.path.join(SAMPLES, filename)) as f:
+        html = f.read()
+    return html
 
 
 class TestArticleOnly(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps=pytest


### PR DESCRIPTION
* Add Python 3.7 classifier to `setup.py`
* Build and test against Python 3.7 on Travis
* Close test file after reading it to avoid `ResourceWarning`
