### PR TITLE
Add __version__ constant to __init__.py, read it in setup.py

### DIFF
--- a/readability/__init__.py
+++ b/readability/__init__.py
@@ -1,1 +1,3 @@
+__version__ = "0.7"
+
 from .readability import Document

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
+
 from __future__ import print_function
-from setuptools import setup, find_packages
+import codecs
+import os
+import re
+from setuptools import setup
 import sys
 
 lxml_requirement = "lxml"
@@ -12,9 +16,29 @@ if sys.platform == 'darwin':
         print("Using lxml<2.4")
         lxml_requirement = "lxml<2.4"
 
+
+# Adapted from https://github.com/pypa/pip/blob/master/setup.py
+def find_version(*file_paths):
+    here = os.path.abspath(os.path.dirname(__file__))
+
+    # Intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with codecs.open(os.path.join(here, *file_paths), 'r') as fp:
+        version_file = fp.read()
+        version_match = re.search(
+            r"^__version__ = ['\"]([^'\"]*)['\"]",
+            version_file,
+            re.M,
+        )
+        if version_match:
+            return version_match.group(1)
+
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name="readability-lxml",
-    version="0.7",
+    version=find_version("readability", "__init__.py"),
     author="Yuri Baburov",
     author_email="burchik@gmail.com",
     description="fast html to text parser (article readability tool) with python3 support",


### PR DESCRIPTION
Hi again Yuri!

I've moved the version string to `__init__.py` so that users of your module (such as us) could just simply read `readability.__version__` instead of installing, importing and using `pkg_resources` from Pip (which is really slow, and Pip complains about upgrades when being imported).

Version string practices: [Single-sourcing the package version](https://packaging.python.org/guides/single-sourcing-package-version/)