### PR TITLE
Use re.Pattern for python 3.7 compatibility and fallback to re._pattern_type in older versions.

### DIFF
--- a/readability/compat/__init__.py
+++ b/readability/compat/__init__.py
@@ -18,3 +18,9 @@ elif sys.version_info[0] == 3:
     str_ = str
     def tostring_(s):
         return tostring(s, encoding='utf-8')
+
+
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type

--- a/readability/readability.py
+++ b/readability/readability.py
@@ -14,7 +14,7 @@ from .htmls import build_doc
 from .htmls import get_body
 from .htmls import get_title
 from .htmls import shorten_title
-from .compat import str_, bytes_, tostring_
+from .compat import str_, bytes_, tostring_, pattern_type
 from .debug import describe, text_content
 
 
@@ -77,7 +77,7 @@ def text_length(i):
 def compile_pattern(elements):
     if not elements:
         return None
-    elif isinstance(elements, re._pattern_type):
+    elif isinstance(elements, pattern_type):
         return elements
     elif isinstance(elements, (str_, bytes_)):
         if isinstance(elements, bytes_):


### PR DESCRIPTION
Fixes #155 