### PR TITLE
Add author

### DIFF
--- a/readability/htmls.py
+++ b/readability/htmls.py
@@ -58,6 +58,15 @@ def get_title(doc):
     return norm_title(title.text)
 
 
+def get_author(doc):
+    author = doc.find(".//meta[@name='author']")
+    if author is None or 'content' not in author.keys() or \
+       len(author.get('content')) == 0:
+        return "[no-author]"
+
+    return author.get('content')
+
+
 def add_match(collection, text, orig):
     text = norm_title(text)
     if len(text.split()) >= 2 and len(text) >= 15:

--- a/readability/readability.py
+++ b/readability/readability.py
@@ -15,6 +15,7 @@ from .cleaners import html_cleaner
 from .htmls import build_doc
 from .htmls import get_body
 from .htmls import get_title
+from .htmls import get_author
 from .htmls import shorten_title
 from .compat import str_, bytes_, tostring_, pattern_type
 from .debug import describe, text_content
@@ -191,6 +192,10 @@ class Document:
     def title(self):
         """Returns document title"""
         return get_title(self._html(True))
+
+    def author(self):
+        """Returns document author"""
+        return get_author(self._html(True))
 
     def short_title(self):
         """Returns cleaned up document title"""

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -124,3 +124,13 @@ class TestArticleOnly(unittest.TestCase):
         sample = load_sample("utf-8-kanji.sample.html")
         doc = Document(sample)
         res = doc.summary()
+
+    def test_author_present(self):
+        sample = load_sample("the-hurricane-rubin-carter-denzel-washington.html")
+        doc = Document(sample)
+        assert 'Alex von Tunzelmann' == doc.author()
+
+    def test_author_absent(self):
+        sample = load_sample("si-game.sample.html")
+        doc = Document(sample)
+        assert '[no-author]' == doc.author()


### PR DESCRIPTION
Pretty straightforward I hope. Readability.js exposes the author. Assuming the document properly uses the <meta name="author" . . . > tag, this patch exposes it here too.