### PR TITLE
Ignore HTML files in github language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/samples/* linguist-vendored


### PR DESCRIPTION
I noticed the HTML documents used for testing make github think this project is predominantly an HTML project.

This .gitattributes file will tell github to ignore those files, so the project will be properly identified as a Python project.