### PR TITLE
Fix test_many_repeated_spaces on darwin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ chardet
 nose
 pep8
 coverage
-timeout_decorator
+wrapt-timeout-decorator

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ speed_deps = [
 
 test_deps = [
     # Test timeouts
-    "timeout_decorator",
+    "wrapt-timeout-decorator",
 ]
 
 extras = {

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -2,8 +2,7 @@ import os
 import unittest
 
 from readability import Document
-import timeout_decorator
-
+from wrapt_timeout_decorator import *
 
 SAMPLES = os.path.join(os.path.dirname(__file__), "samples")
 
@@ -101,7 +100,7 @@ class TestArticleOnly(unittest.TestCase):
         assert not "aside" in s
 
     # Many spaces make some regexes run forever
-    @timeout_decorator.timeout(seconds=3, use_signals=False)
+    @timeout(3, use_signals=False)
     def test_many_repeated_spaces(self):
         long_space = " " * 1000000
         sample = "<html><body><p>foo" + long_space + "</p></body></html>"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    py{27,35,36,37,38,py,py3}, doc
+    py{27,35,36,37,38,39,310,py,py3}, doc
 skip_missing_interpreters =
     True
 


### PR DESCRIPTION
Replace `timeout_decorator` with `wrapt-timeout-decorator` to fix exceptions during testing.

Fixes #177
