### PR TITLE
Fix/upgrade sphinx build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
-    "recommonmark",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,7 +72,7 @@ release = readability.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-lxml
+lxml[html_clean]
 chardet
 nose
 pep8

--- a/setup.py
+++ b/setup.py
@@ -21,14 +21,25 @@ speed_deps = [
      "cchardet",
 ]
 
+def _get_html_clean_deps():
+    if lxml_requirement != "lxml":
+        return []
+    if sys.version_info <= (3, 11):
+        return ["lxml", "lxml_html_clean"]
+    return ["lxml[html_clean]"]
+
+
+html_clean_deps = _get_html_clean_deps()
+
 test_deps = [
     # Test timeouts
     "wrapt-timeout-decorator",
-]
+] + html_clean_deps
 
 extras = {
     'speed': speed_deps,
     'test': test_deps,
+    'html_clean': html_clean_deps
 }
 
 # Adapted from https://github.com/pypa/pip/blob/master/setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest
     doc: sphinx
     doc: sphinx_rtd_theme
-    doc: recommonmark
+    doc: myst-parser
 
 # This creates the virtual envs with --site-packages so already packages
 # that are already installed will be reused. This is especially useful on

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,5 @@ commands =
 
 [testenv:doc]
 commands =
-    python setup.py build_sphinx
+    pip install -r requirements.txt -e ".[test]"
+    sphinx-build -b html doc/source build/


### PR DESCRIPTION
Includes commits from #183.

- Upgrade process used to build docs to currently supported methods
- swap out now unsupported `recommonmark` for `myst-parser`