### PR TITLE
Fix issue #89, introduce flag option to keep images in summary.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 lxml
+lxml_html_clean
+pytest
 chardet
 nose
 pep8

--- a/tests/samples/summary-keep-all-images.sample.html
+++ b/tests/samples/summary-keep-all-images.sample.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<body>
+<h2>
+    <span>
+        H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline H2 Headline
+    </span>
+</h2>
+<p>
+    <spa>
+        Text Text Text Text Text Text Text Text Text Text
+    </spa>
+</p>
+<div>
+    <span>
+        <a>
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpSLVDnYQcchQnSyIFXHUKhShQqgVWnUweekfNDEkKS6OgmvBwZ/FqoOLs64OroIg+APiLjgpukiJ9yWFFjFeeLyP8+45vHcfIDSqTLO6xgFNt81MKinm8iti6BUBhBFBPxIys4xZSUrDt77uqZvqLs6z/Pv+rD61YDEgIBLPMMO0ideJpzZtg/M+cZSVZZX4nHjMpAsSP3Jd8fiNc8llgWdGzWxmjjhKLJY6WOlgVjY14knimKrplC/kPFY5b3HWqjXWuid/YbigLy9xndYwUljAIiSIUFBDBVXYiNOuk2IhQ+dJH/+Q65fIpZCrAkaOeWxAg+z6wf/g92ytYmLCSwonge4Xx/kYAUK7QLPuON/HjtM8AYLPwJXe9m80gOlP0uttLXYERLaBi+u2puwBlzvA4JMhm7IrBWkJxSLwfkbflAcGboHeVW9urXOcPgBZmlX6Bjg4BEZLlL3m8+6ezrn929Oa3w9e03KfJqsuOAAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAAd0SU1FB+kBDA8PKt1W5MYAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAAFUlEQVQY02P8x+rFgBswMeAFI1UaAJ65AWFYB2G5AAAAAElFTkSuQmCC"
+            />
+         </a>
+    </span>
+</div>
+<p>
+    <spa>
+        Text Text Text Text Text Text Text Text Text Text
+    </spa>
+</p>
+</body>
+</html>

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -133,3 +133,24 @@ class TestArticleOnly(unittest.TestCase):
         sample = load_sample("si-game.sample.html")
         doc = Document(sample)
         assert '[no-author]' == doc.author()
+
+    def test_keep_images_present(self):
+        sample = load_sample("summary-keep-all-images.sample.html")
+
+        doc = Document(sample)
+
+        assert "<img" in doc.summary(keep_all_images=True)
+
+    def test_keep_images_absent(self):
+        sample = load_sample("summary-keep-all-images.sample.html")
+
+        doc = Document(sample)
+
+        assert "<img" not in doc.summary(keep_all_images=False)
+
+    def test_keep_images_absent_by_defautl(self):
+        sample = load_sample("summary-keep-all-images.sample.html")
+
+        doc = Document(sample)
+
+        assert "<img" not in doc.summary()


### PR DESCRIPTION
Hello,

This PR adds a flag to keep images normally removed in the summary() option. The problem once was discussed in issue #89 and a flag was suggested as solution. The flag is by default disabled and needs to be enabled to be used.

I would appreciate if you could merge this PR into the main branch. 

Additionally, I like to ask you to deploy a new version to PyPI.

Kind regards,
Axel 