### PR TITLE
Document - Correct when instantiated with bytes content instead of bytes

### DIFF
--- a/readability/encoding.py
+++ b/readability/encoding.py
@@ -5,9 +5,9 @@ except ImportError:
     import chardet
 
 
-RE_CHARSET = re.compile(r'<meta.*?charset=["\']*(.+?)["\'>]', flags=re.I)
-RE_PRAGMA = re.compile(r'<meta.*?content=["\']*;?charset=(.+?)["\'>]', flags=re.I)
-RE_XML = re.compile(r'^<\?xml.*?encoding=["\']*(.+?)["\'>]')
+RE_CHARSET = re.compile(br'<meta.*?charset=["\']*(.+?)["\'>]', flags=re.I)
+RE_PRAGMA = re.compile(br'<meta.*?content=["\']*;?charset=(.+?)["\'>]', flags=re.I)
+RE_XML = re.compile(br'^<\?xml.*?encoding=["\']*(.+?)["\'>]')
 
 CHARSETS = {
     "big5": "big5hkscs",
@@ -53,11 +53,11 @@ def get_encoding(page):
 
     # Fallback to chardet if declared encodings fail
     # Remove all HTML tags, and leave only text for chardet
-    text = re.sub(r'(\s*</?[^>]*>)+\s*', ' ', page).strip()
     enc = 'utf-8'
+    text = re.sub(r'(\s*</?[^>]*>)+\s*', ' ', page.decode(enc, "replace")).strip()
     if len(text) < 10:
         return enc  # can't guess
-    res = chardet.detect(text)
+    res = chardet.detect(page)
     enc = res["encoding"] or "utf-8"
     # print '->', enc, "%.2f" % res['confidence']
     enc = fix_charset(enc)

--- a/tests/test_article_only.py
+++ b/tests/test_article_only.py
@@ -94,6 +94,17 @@ class TestArticleOnly(unittest.TestCase):
         doc = Document(sample)
         doc.summary()
 
+    def test_html_input_in_bytes(self):
+        sample = (
+            b'<html class="article" id="body">'
+            b"   <body>"
+            b"       <p>1234567890123456789012345</p>"
+            b"   </body>"
+            b"</html>"
+        )
+        doc = Document(sample)
+        doc.summary()
+
     def test_correct_cleanup(self):
         sample = """
         <html>


### PR DESCRIPTION
## Actual Behavior
Document.summary()  is not working with python3 when the document is based on bytes and not on string content.
The new released version (0.8.4.1) contains [an old modification](https://github.com/buriy/python-readability/commit/6872c948e498118b40dbbc81a63ce8db3bcda422#diff-8f3e5304f3130031d4e879454f79d55f8f614b475378b08d9277fc0c96fb765eR6-R8) that put the regexp in string instead of bytes.

Linked issue :
https://github.com/buriy/python-readability/issues/194

## Steps to Reproduce the Problem
Follow the readme steps
```python
>>> import requests
>>> from readability import Document

>>> response = requests.get('http://example.com')
>>> doc = Document(response.content)
>>> doc.title()
Traceback (most recent call last):
...
    RE_CHARSET.findall(page) + RE_PRAGMA.findall(page) + RE_XML.findall(page)
    ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot use a string pattern on a bytes-like object
```